### PR TITLE
Refactor Event System: Introduce Dispatchable Base Class

### DIFF
--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/DeadEvent.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/DeadEvent.kt
@@ -1,5 +1,7 @@
 package com.fantamomo.kevent
 
+import kotlin.reflect.KClass
+
 /**
  * Represents an event that could not be delivered to any registered listeners.
  *
@@ -18,4 +20,8 @@ package com.fantamomo.kevent
  * @author Fantamomo
  * @since 1.0-SNAPSHOT
  */
-class DeadEvent(val event: Event) : Event()
+class DeadEvent(val event: Dispatchable) : Dispatchable() {
+    companion object : Listenable<DeadEvent> {
+        override val eventType: KClass<DeadEvent> = DeadEvent::class
+    }
+}

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Dispatchable.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Dispatchable.kt
@@ -1,0 +1,43 @@
+package com.fantamomo.kevent
+
+import kotlin.reflect.KClass
+
+/**
+ * Represents a dispatchable entity in the event system.
+ *
+ * A dispatchable is the base class for all events within this event handling framework.
+ * It serves as the foundational type that can be extended to define custom events.
+ * Subclasses of `Dispatchable` are designed to provide specific event-related functionality
+ * and can be dispatched within the system.
+ *
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
+abstract class Dispatchable {
+    /**
+     * Classes inheriting from `Dispatchable` should implement this interface in their companion
+     * objects, allowing developers to use extension functions directly on the event type
+     * for easier listener registration and management.
+     *
+     * @param E The type of event that the implementing class represents. This must extend
+     *          from `Dispatchable` to ensure compatibility with the event system.
+     * @author Fantamomo
+     * @since 1.0-SNAPSHOT
+     */
+    interface Listenable<E : Dispatchable> {
+        /**
+         * The type of event represented by this listenable instance.
+         *
+         * This property provides the Kotlin class corresponding to the event type `E`.
+         * It is used to identify and dispatch events of the specified type within
+         * the event-handling system.
+         *
+         * @property eventType The class type of the event `E`, which extends `Dispatchable`.
+         */
+        val eventType: KClass<E>
+    }
+
+    companion object : Listenable<Dispatchable> {
+        override val eventType: KClass<Dispatchable> = Dispatchable::class
+    }
+}

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Event.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Event.kt
@@ -3,79 +3,18 @@ package com.fantamomo.kevent
 import kotlin.reflect.KClass
 
 /**
- * Base class for all events in the event system.
- * 
- * Events are objects that are passed to event handlers when they are triggered.
- * Custom events should extend this class to be compatible with the event system.
- * 
- * Example of a custom event:
- * ```
- * class MyEvent(val data: String) : Event() {
- *     // Additional properties and methods specific to this event
- * }
- * ```
- * 
- * When an event is dispatched, it is passed to all registered event handlers
- * that accept its type or a supertype. The event handlers can then access the
- * event's properties and methods to handle the event appropriately.
- * 
- * @see Listener
- * @see Register
+ * Represents a base class for events in the event dispatch system.
+ *
+ * The `Event` class is an abstract subclass of `Dispatchable` that enables the creation
+ * of specific event types. Any event in the system should inherit from this class.
+ * It extends the functionality provided by the `Dispatchable` class to allow event handling
+ * and dispatching within the system.
  *
  * @author Fantamomo
  * @since 1.0-SNAPSHOT
  */
-open class Event {
-
-    /**
-     * The name of the event class derived from its simple class name.
-     *
-     * This property holds the simple name of the event class and is used as an identifier
-     * for event instances. If the class does not have a name (e.g., anonymous classes),
-     * an [IllegalArgumentException] is thrown. Ensures all events have a meaningful name
-     * for identification within the event system.
-     *
-     * @throws IllegalArgumentException if the event class does not have a name
-     */
-    val name: String = this::class.simpleName ?: throw IllegalArgumentException("Event class must have a name")
-
-    /**
-     * Interface to be implemented by `companion object`s of subclasses inheriting from [Event].
-     *
-     * This interface is intended to mark companion objects as registrable entry points
-     * for event-related extension functions. By implementing this interface, the companion
-     * object can be used in a type-safe way to register listeners or interact with the event
-     * system through extensions.
-     *
-     * It is recommended that all `companion object`s of event subclasses implement this interface
-     * to enable convenient and consistent registration of event handlers via extensions.
-     *
-     * Example:
-     * ```
-     * class MyEvent(val data: String) : Event() {
-     *     companion object : Registrable<MyEvent> {
-     *         override val eventType = MyEvent::class
-     *     }
-     * }
-     *
-     * fun <E : Event> Registrable<E>.register(handler: (E) -> Unit) {
-     *     // Register the handler for this event type
-     * }
-     *
-     * // Usage:
-     * MyEvent.register { println(it.data) }
-     * ```
-     *
-     * @param E The type of event associated with this companion object
-     */
-    interface Registrable<E : Event> {
-        /**
-         * Represents the type of event associated with this registrable companion object.
-         */
-        val eventType: KClass<E>
-    }
-
-    companion object : Registrable<Event> {
+abstract class Event : Dispatchable() {
+    companion object : Listenable<Event> {
         override val eventType: KClass<Event> = Event::class
     }
 }

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/EventConfiguration.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/EventConfiguration.kt
@@ -19,7 +19,7 @@ package com.fantamomo.kevent
  * @author Fantamomo
  * @since 1.0-SNAPSHOT
  */
-class EventConfiguration<E : Event>(private val data: Map<Key<*>, Any?>) {
+class EventConfiguration<E : Dispatchable>(private val data: Map<Key<*>, Any?>) {
     /**
      * Creates a new configuration from an [EventConfigurationScope].
      * 
@@ -86,6 +86,6 @@ class EventConfiguration<E : Event>(private val data: Map<Key<*>, Any?>) {
          * @return The default [EventConfiguration] instance for the specified event type [E].
          */
         @Suppress("UNCHECKED_CAST")
-        fun <E : Event> default() = DEFAULT as EventConfiguration<E>
+        fun <E : Dispatchable> default() = DEFAULT as EventConfiguration<E>
     }
 }

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/EventConfigurationScope.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/EventConfigurationScope.kt
@@ -32,7 +32,7 @@ package com.fantamomo.kevent
  * @since 1.0-SNAPSHOT
  */
 @EventDsl
-class EventConfigurationScope<E : Event> {
+class EventConfigurationScope<E : Dispatchable> {
     /**
      * Internal storage for configuration data.
      */

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/config.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/config.kt
@@ -50,7 +50,7 @@ import kotlin.jvm.JvmSynthetic
 @Throws(ConfigurationCapturedException::class)
 @OptIn(ExperimentalContracts::class)
 @JvmSynthetic
-inline fun <E : Event> configuration(event: E?, @EventDsl block: EventConfigurationScope<E>.() -> Unit) {
+inline fun <E : Dispatchable> configuration(event: E?, @EventDsl block: EventConfigurationScope<E>.() -> Unit) {
     contract {
         returns() implies (event != null)
         callsInPlace(block, InvocationKind.AT_MOST_ONCE)
@@ -95,10 +95,11 @@ inline fun <E : Event> configuration(event: E?, @EventDsl block: EventConfigurat
  * @author Fantamomo
  * @since 1.0-SNAPSHOT
  */
+@Suppress("NOTHING_TO_INLINE")
 @Throws(ConfigurationCapturedException::class)
 @OptIn(ExperimentalContracts::class)
 @JvmSynthetic
-fun emptyConfiguration(event: Event?) {
+inline fun emptyConfiguration(event: Dispatchable?) {
     contract { returns() implies (event != null) }
     if (event == null) throw ConfigurationCapturedException(EventConfiguration.DEFAULT)
 }
@@ -121,7 +122,7 @@ fun emptyConfiguration(event: Event?) {
  */
 @OptIn(ExperimentalContracts::class)
 @JvmSynthetic
-inline fun <E : Event> createConfigurationScope(block: @EventDsl EventConfigurationScope<E>.() -> Unit): EventConfiguration<E> {
+inline fun <E : Dispatchable> createConfigurationScope(block: @EventDsl EventConfigurationScope<E>.() -> Unit): EventConfiguration<E> {
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     val scope = EventConfigurationScope<E>()
     scope.block()

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/util.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/util.kt
@@ -18,4 +18,4 @@ package com.fantamomo.kevent
  * @author Fantamomo
  * @since 1.0-SNAPSHOT
  */
-fun <E : Event, T> EventConfigurationScope<E>.getOrDefault(key: Key<T>): T = get(key) ?: key.defaultValue
+fun <T> EventConfigurationScope<*>.getOrDefault(key: Key<T>): T = get(key) ?: key.defaultValue

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
@@ -37,7 +37,7 @@ interface EventManager {
      *
      * @param event The event instance to be dispatched to the appropriate listeners.
      */
-    fun dispatch(event: Event)
+    fun dispatch(event: Dispatchable)
 
     /**
      * Registers an event-specific handler with its configuration.
@@ -54,7 +54,7 @@ interface EventManager {
      * @see createConfigurationScope
      * @see EventConfigurationScope
      */
-    fun <E : Event> register(
+    fun <E : Dispatchable> register(
         event: KClass<E>,
         configuration: EventConfiguration<E> = EventConfiguration.default(),
         handler: (E) -> Unit


### PR DESCRIPTION
This PR updates the class hierarchy of the event system.
A new abstract base class Dispatchable has been introduced, which Event now extends. This allows for greater flexibility, e.g., supporting non-standard dispatchables like DeadEvent that don't semantically fit under Event.

The EventManager and related classes (in a separate Gradle module) have been updated accordingly to support this change.

It is still recommended to extend Event for custom event types unless there's a specific need to use Dispatchable directly.