### PR TITLE
Add custom parameter resolution for EventManager

### DIFF
--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/utils/InjectionName.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/utils/InjectionName.kt
@@ -1,0 +1,20 @@
+package com.fantamomo.kevent.utils
+
+
+/**
+ * This annotation allows overriding the injection name of a parameter when applied.
+ * By default, the parameter name is used as the injection name.
+ * This provides the ability to assign
+ * a different name to the injected value than the parameter name.
+ *
+ * It is solely used for parameter injection of custom values within listener
+ * methods.
+ *
+ * @property value The custom injection name to be used for the parameter.
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class InjectionName(val value: String)

--- a/k-event-manager/build.gradle.kts
+++ b/k-event-manager/build.gradle.kts
@@ -23,5 +23,8 @@ kotlin {
                 implementation("org.jetbrains.kotlin:kotlin-test")
             }
         }
+        all {
+            languageSettings.enableLanguageFeature("BreakContinueInInlineLambdas")
+        }
     }
 }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -2,6 +2,7 @@ package com.fantamomo.kevent.manager
 
 import com.fantamomo.kevent.*
 import com.fantamomo.kevent.manager.components.*
+import com.fantamomo.kevent.utils.InjectionName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -15,6 +16,7 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.jvm.isAccessible
@@ -57,7 +59,8 @@ class DefaultEventManager internal constructor(
 
             val parameters = method.parameters
             val resolvers = parameters.dropWhile { it.index < 2 }.associateWith { parameter ->
-                parameterResolver.find { it.name == parameter.name && it.type == parameter.type.classifier }
+                parameterResolver.find {
+                    (parameter.findAnnotation<InjectionName>()?.value ?: it.name) == parameter.name && it.type == parameter.type.classifier }
                     ?: continue@out
             }
             if (parameters.size < 2) continue

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -60,7 +60,7 @@ class DefaultEventManager internal constructor(
             val parameters = method.parameters
             val resolvers = parameters.dropWhile { it.index < 2 }.associateWith { parameter ->
                 parameterResolver.find {
-                    (parameter.findAnnotation<InjectionName>()?.value ?: it.name) == parameter.name && it.type == parameter.type.classifier }
+                    it.name == (parameter.findAnnotation<InjectionName>()?.value ?: parameter.name) && it.type == parameter.type.classifier }
                     ?: continue@out
             }
             if (parameters.size < 2) continue

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -1,15 +1,18 @@
 package com.fantamomo.kevent.manager
 
 import com.fantamomo.kevent.*
-import com.fantamomo.kevent.manager.components.EventManagerComponent
-import com.fantamomo.kevent.manager.components.ExceptionHandler
-import com.fantamomo.kevent.manager.components.getOrThrow
+import com.fantamomo.kevent.manager.components.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.hasAnnotation
@@ -19,6 +22,7 @@ import kotlin.reflect.jvm.jvmName
 
 class DefaultEventManager internal constructor(
     components: EventManagerComponent<*>,
+    defaultParameterInjection: Boolean,
 ) : EventManager {
 
     private val handlers: ConcurrentHashMap<KClass<out Dispatchable>, HandlerList<out Dispatchable>> =
@@ -26,14 +30,37 @@ class DefaultEventManager internal constructor(
 
     private val exceptionHandler = components.getOrThrow(ExceptionHandler)
 
+    private val parameterResolver: List<ListenerParameterResolver<*>>
+
+    private val scope: CoroutineScope =
+        components[EventCoroutineScope]?.scope ?: CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    init {
+        var components = components
+        if (defaultParameterInjection) {
+            components += ListenerParameterResolver.static("manager", EventManager::class, this) +
+                    ListenerParameterResolver.static("logger", Logger::class, logger) +
+                    ListenerParameterResolver.static(
+                        "scope",
+                        CoroutineScope::class,
+                        CoroutineScope(Dispatchers.Default + SupervisorJob(scope.coroutineContext.job))
+                    )
+        }
+        parameterResolver = components.getAll(ListenerParameterResolver.Key)
+    }
+
     override fun register(listener: Listener) {
         val listenerClass = listener::class
-        for (method in listenerClass.declaredMemberFunctions) {
+        out@ for (method in listenerClass.declaredMemberFunctions) {
             if (!method.hasAnnotation<Register>()) continue
             if (method.visibility != KVisibility.PUBLIC) continue
 
             val parameters = method.parameters
-            if (parameters.size != 2) continue
+            val resolvers = parameters.dropWhile { it.index < 2 }.associateWith { parameter ->
+                parameterResolver.find { it.name == parameter.name && it.type == parameter.type.classifier }
+                    ?: continue@out
+            }
+            if (parameters.size < 2) continue
 
             val eventClass = parameters[1].type.classifier as? KClass<*> ?: continue
             if (!Dispatchable::class.isSuperclassOf(eventClass)) continue
@@ -41,9 +68,13 @@ class DefaultEventManager internal constructor(
             @Suppress("UNCHECKED_CAST")
             val typedEventClass = eventClass as KClass<Dispatchable>
 
+            val arguments = mapOf(
+                parameters[0] to listener,
+                parameters[1] to null
+            ) + resolvers.mapValues { it.value.valueByConfiguration }
             try {
                 method.isAccessible = true
-                method.call(listener, null)
+                method.callBy(arguments)
             } catch (e: InvocationTargetException) {
                 val config = (e.targetException as? ConfigurationCapturedException)?.configuration
                 if (config !is EventConfiguration<*>) continue
@@ -53,7 +84,8 @@ class DefaultEventManager internal constructor(
                     type = typedEventClass,
                     listener = listener,
                     kFunction = method,
-                    configuration = config as EventConfiguration<Dispatchable>
+                    configuration = config as EventConfiguration<Dispatchable>,
+                    resolvers = resolvers
                 )
 
                 getOrCreateHandlerList(typedEventClass).add(handler)
@@ -122,8 +154,10 @@ class DefaultEventManager internal constructor(
 
     private inner class HandlerList<E : Dispatchable> {
         private val listeners: MutableList<RegisteredListener<E>> = mutableListOf()
+
         @Volatile
         private var sortedListeners: List<RegisteredListener<E>> = emptyList()
+
         @Volatile
         private var dirty: Boolean = true
 
@@ -197,8 +231,20 @@ class DefaultEventManager internal constructor(
         override val listener: Listener,
         val kFunction: KFunction<*>,
         configuration: EventConfiguration<E>,
+        val resolvers: Map<KParameter, ListenerParameterResolver<*>>,
     ) : RegisteredListener<E>(type, listener, configuration) {
-        override val method: (E) -> Unit = { evt -> kFunction.call(listener, evt) }
+        private val thisParameter = kFunction.parameters[0]
+        private val eventParameter = kFunction.parameters[1]
+        override val method: (E) -> Unit = { evt ->
+            val args = mapOf(thisParameter to listener, eventParameter to evt) + resolvers.mapValues {
+                it.value.resolve(
+                    listener,
+                    kFunction,
+                    evt
+                )
+            }
+            kFunction.callBy(args)
+        }
     }
 
     companion object {

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/components/ListenerParameterResolver.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/components/ListenerParameterResolver.kt
@@ -5,6 +5,18 @@ import com.fantamomo.kevent.Listener
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 
+/**
+ * Interface for resolving dynamic or static parameters for listener methods in an event system.
+ *
+ * Listener methods in the event system can define additional parameters, which are resolved
+ * dynamically or statically when the method is invoked. Implementations of this interface
+ * provide mechanisms to fulfill these parameters by supplying appropriate values based on
+ * context such as the listener, method information, or the event being dispatched.
+ *
+ * @param T The type of the parameter value resolved by this resolver. Must be a non-nullable type.
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
 interface ListenerParameterResolver<T : Any> : EventManagerComponent<ListenerParameterResolver<T>> {
     @Suppress("UNCHECKED_CAST")
     override val key

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/components/ListenerParameterResolver.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/components/ListenerParameterResolver.kt
@@ -1,0 +1,73 @@
+package com.fantamomo.kevent.manager.components
+
+import com.fantamomo.kevent.Dispatchable
+import com.fantamomo.kevent.Listener
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+
+interface ListenerParameterResolver<T : Any> : EventManagerComponent<ListenerParameterResolver<T>> {
+    @Suppress("UNCHECKED_CAST")
+    override val key
+        get() = Key as EventManagerComponent.Key<ListenerParameterResolver<T>>
+
+    val name: String
+    val type: KClass<T>
+    val valueByConfiguration: T
+
+    object Key : EventManagerComponent.Key<ListenerParameterResolver<Nothing>> {
+        @Suppress("UNCHECKED_CAST")
+        override val clazz = ListenerParameterResolver::class as KClass<ListenerParameterResolver<Nothing>>
+    }
+
+    fun resolve(listener: Listener?, methode: KFunction<*>?, event: Dispatchable): T
+
+    class DynamicListenerParameterResolver<T : Any>(
+        override val name: String,
+        override val type: KClass<T>,
+        override val valueByConfiguration: T,
+        val valueProvider: (listener: Listener?, methode: KFunction<*>?, event: Dispatchable) -> T,
+    ) : ListenerParameterResolver<T> {
+        override fun resolve(
+            listener: Listener?,
+            methode: KFunction<*>?,
+            event: Dispatchable,
+        ) = valueProvider(listener, methode, event)
+    }
+
+    class StaticListenerParameterResolver<T : Any>(
+        override val name: String,
+        override val type: KClass<T>,
+        override val valueByConfiguration: T,
+        val value: T,
+    ) : ListenerParameterResolver<T> {
+        override fun resolve(
+            listener: Listener?,
+            methode: KFunction<*>?,
+            event: Dispatchable,
+        ) = value
+    }
+
+    companion object {
+        fun <T : Any> dynamic(
+            name: String,
+            type: KClass<T>,
+            valueByConfiguration: T,
+            valueProvider: (listener: Listener?, methode: KFunction<*>?, event: Dispatchable) -> T,
+        ): ListenerParameterResolver<T> =
+            DynamicListenerParameterResolver(name, type, valueByConfiguration, valueProvider)
+
+        fun <T : Any> dynamic(
+            name: String,
+            type: KClass<T>,
+            valueByConfiguration: T,
+            valueProvider: () -> T,
+        ): ListenerParameterResolver<T> =
+            DynamicListenerParameterResolver(name, type, valueByConfiguration, { _, _, _ -> valueProvider() })
+
+        fun <T : Any> static(
+            name: String,
+            type: KClass<T>,
+            value: T,
+        ) = StaticListenerParameterResolver(name, type, value, value)
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/factory.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/factory.kt
@@ -7,9 +7,9 @@ import com.fantamomo.kevent.manager.components.EventManagerComponent
 import com.fantamomo.kevent.manager.components.ExceptionHandler
 import com.fantamomo.kevent.manager.components.addIfAbsent
 
-fun EventManager(): EventManager = EventManager(ComponentSet.of())
+fun EventManager(defaultParameterInjection: Boolean = true): EventManager = EventManager(ComponentSet.of(), defaultParameterInjection)
 
-fun EventManager(components: EventManagerComponent<*>): EventManager {
+fun EventManager(components: EventManagerComponent<*>, defaultParameterInjection: Boolean = true): EventManager {
     val component = components.addIfAbsent(ExceptionHandler.Empty)
-    return DefaultEventManager(component)
+    return DefaultEventManager(component, defaultParameterInjection)
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the `DefaultEventManager` and related components:

- Added support for the `InjectionName` annotation to allow custom parameter name overrides for listener method injection.
- Implemented the `ListenerParameterResolver` interface for dynamic and static listener parameter resolution.
- Enhanced listener invocation logic with custom resolvers and a `defaultParameterInjection` configuration flag.
- Enabled `BreakContinueInInlineLambdas` Kotlin language feature to support project requirements.