### PR TITLE
Add async event handling with suspend dispatcher support

### DIFF
--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -225,7 +225,7 @@ class DefaultEventManager internal constructor(
                 ) continue
                 called = true
                 if (handler.isSuspend) {
-                    scope.launch {
+                    scope.launch(Dispatchers.Unconfined) {
                         try {
                             handler.invokeSuspend(typedEvent, false)
                         } catch (e: Throwable) {

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -36,7 +36,7 @@ class DefaultEventManager internal constructor(
                     ListenerParameterResolver.static(
                         "scope",
                         CoroutineScope::class,
-                        CoroutineScope(Dispatchers.Default + SupervisorJob(scope.coroutineContext.job))
+                        CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
                     ) +
                     IsWaitingParameterResolver
         }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
@@ -40,6 +40,18 @@ interface EventManager {
     fun dispatch(event: Dispatchable)
 
     /**
+     * Dispatches an event to all registered event listeners asynchronously.
+     *
+     * This suspend function delivers the given [event] to all applicable listeners
+     * or handlers subscribed to the event type or its supertypes. Unlike its synchronous
+     * counterpart, this method allows asynchronous processing within a coroutine
+     * context, enabling non-blocking or delayed execution of event handling logic.
+     *
+     * @param event The event instance to be dispatched to the appropriate listeners.
+     */
+    suspend fun dispatchSuspend(event: Dispatchable)
+
+    /**
      * Registers an event-specific handler with its configuration.
      *
      * This method allows for registering a handler for a specific type of event. The handler


### PR DESCRIPTION
This pull request introduces support for asynchronous event dispatch and suspend handler invocation in the `DefaultEventManager` and `EventManager`. Key changes include:

1. **New Feature**: 
   - Introduced `dispatchSuspend` to enable asynchronous, non-blocking event handling.
   - Support for invoking suspend functions as event handlers.

2. **Bug Fixes**:
   - Corrected `CoroutineScope` initialization for proper coroutine job hierarchy.

3. **Documentation**:
   - Updated README with details on suspend event handling and examples for `dispatchSuspend`.
   - Clarified behavior of `isWaiting` in documentation.