### PR TITLE
Add configurable settings for parameter injection and event dispatching

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,21 @@ the listener can be registered.
 Sometimes you need in the function another variable name instead of the injection name,
 if that happened you can use `@InjectionName`, where the name in brackets is the name that is uses in the system.
 
+There are 4 default injectable parameter:
+
+- `manager: EventManager`: The instance of the EventManager is passed, which calls the handler.
+- `logger: Logger`: A instance for logging, all `DefaultEventManager` have the same.
+- `scope: CoroutineScope`: It can be used to launch new coroutines.
+- `isWaiting: Boolean`: For non suspend handler it will always be `true`, for suspend handler:
+  - when called with `dispatch` it is `false`
+  - when called with `dispatchSuspend` it is `true`
+
+The following example disables `scope` and `logger`:
+
+```kotlin
+EventManager(Settings.DISABLE_SCOPE_INJECTION.with(true) + Settings.DISABLE_LOGGER_INJECTION.with(true))
+```
+
 ---
 
 ## Generic Events

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/factory.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/factory.kt
@@ -7,9 +7,9 @@ import com.fantamomo.kevent.manager.components.EventManagerComponent
 import com.fantamomo.kevent.manager.components.ExceptionHandler
 import com.fantamomo.kevent.manager.components.addIfAbsent
 
-fun EventManager(defaultParameterInjection: Boolean = true): EventManager = EventManager(ComponentSet.of(), defaultParameterInjection)
+fun EventManager(): EventManager = EventManager(ComponentSet.of())
 
-fun EventManager(components: EventManagerComponent<*>, defaultParameterInjection: Boolean = true): EventManager {
+fun EventManager(components: EventManagerComponent<*>): EventManager {
     val component = components.addIfAbsent(ExceptionHandler.Empty)
-    return DefaultEventManager(component, defaultParameterInjection)
+    return DefaultEventManager(component)
 }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/LazySettingsEntry.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/LazySettingsEntry.kt
@@ -1,0 +1,18 @@
+package com.fantamomo.kevent.manager.settings
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+internal class LazySettingsEntry<T>(val type: KClass<T & Any>, val defaultValue: T) : ReadOnlyProperty<Settings, SettingsEntry<T>> {
+    private lateinit var entry: SettingsEntry<T>
+
+    override fun getValue(
+        thisRef: Settings,
+        property: KProperty<*>,
+    ): SettingsEntry<T> {
+        if (::entry.isInitialized) return entry
+        entry = SettingsEntry(property.name, type, defaultValue)
+        return entry
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/Settings.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/Settings.kt
@@ -1,0 +1,49 @@
+package com.fantamomo.kevent.manager.settings
+
+import kotlin.reflect.KClass
+
+/**
+ * Singleton object containing configurable settings for event dispatching behavior.
+ *
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
+object Settings {
+    /**
+     * A setting that disables the injection of the `isWaiting:` [Boolean] state into parameter resolution during
+     * event dispatching.
+     *
+     * By default, the value is `false`, meaning the `isWaiting` injection is enabled. Setting this to
+     * `true` will turn off this behavior.
+     */
+    val DISABLE_IS_WAITING_INJECTION by setting(false)
+    /**
+     * A setting that disables the injection of the `manager:` [com.fantamomo.kevent.manager.EventManager] state into parameter resolution during
+     * event dispatching.
+     *
+     * By default, the value is `false`, meaning the `manager` injection is enabled. Setting this to
+     * `true` will turn off this behavior.
+     */
+    val DISABLE_EVENTMANAGER_INJECTION by setting(false)
+    /**
+     * A setting that disables the injection of the `scope:` [kotlinx.coroutines.CoroutineScope] state into parameter resolution during
+     * event dispatching.
+     *
+     * By default, the value is `false`, meaning the `scope` injection is enabled. Setting this to
+     * `true` will turn off this behavior.
+     */
+    val DISABLE_SCOPE_INJECTION by setting(false)
+    /**
+     * A setting that disables the injection of the `logger:` [java.util.logging.Logger] state into parameter resolution during
+     * event dispatching.
+     *
+     * By default, the value is `false`, meaning the `scope` injection is enabled. Setting this to
+     * `true` will turn off this behavior.
+     */
+    val DISABLE_LOGGER_INJECTION by setting(false)
+
+
+    private inline fun <reified T> setting(name: String, defaultValue: T) = SettingsEntry<T>(name, defaultValue)
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified T> setting(defaultValue: T) = LazySettingsEntry(T::class as KClass<T & Any>, defaultValue)
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/SettingsComponent.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/SettingsComponent.kt
@@ -1,0 +1,15 @@
+package com.fantamomo.kevent.manager.settings
+
+import com.fantamomo.kevent.manager.components.EventManagerComponent
+import kotlin.reflect.KClass
+
+data class SettingsComponent<T>(val entry: SettingsEntry<T>, val value: T) : EventManagerComponent<SettingsComponent<T>> {
+
+    @Suppress("UNCHECKED_CAST")
+    override val key: EventManagerComponent.Key<SettingsComponent<T>> = Key as EventManagerComponent.Key<SettingsComponent<T>>
+
+    object Key : EventManagerComponent.Key<SettingsComponent<Nothing>> {
+        @Suppress("UNCHECKED_CAST")
+        override val clazz = SettingsComponent::class as KClass<SettingsComponent<Nothing>>
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/SettingsEntry.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/SettingsEntry.kt
@@ -1,0 +1,15 @@
+package com.fantamomo.kevent.manager.settings
+
+import kotlin.reflect.KClass
+
+data class SettingsEntry<T>(
+    val name: String,
+    val type: KClass<T & Any>,
+    val defaultValue: T,
+) {
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        inline operator fun <reified T> invoke(name: String, defaultValue: T) =
+            SettingsEntry(name, T::class as KClass<T & Any>, defaultValue)
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/setting.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/setting.kt
@@ -1,0 +1,48 @@
+package com.fantamomo.kevent.manager.settings
+
+import com.fantamomo.kevent.manager.components.ComponentSet
+import com.fantamomo.kevent.manager.components.EventManagerComponent
+
+/**
+ * Associates the given value with the current settings entry, creating a [SettingsComponent] instance.
+ *
+ * @param value The value to associate with this `SettingsEntry`.
+ * @return A `SettingsComponent` that pairs the `SettingsEntry` with the provided value.
+ *
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T> SettingsEntry<T>.with(value: T) = SettingsComponent(this, value)
+
+/**
+ * Retrieves the setting value associated with the given [SettingsEntry] from the current [ComponentSet].
+ * If no associated value is found in the [ComponentSet], the default value of the [SettingsEntry] is returned.
+ *
+ * @param entry The [SettingsEntry] representing the setting to be retrieved.
+ * @return The value associated with the provided [SettingsEntry], or its default value if not present.
+ *
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> ComponentSet.getSetting(entry: SettingsEntry<T>): T =
+    (components.find { (it as? SettingsComponent<T>)?.entry === entry } as? SettingsComponent<T>)?.value
+        ?: entry.defaultValue
+
+/**
+ * Retrieves the value associated with the provided [SettingsEntry] from the current [EventManagerComponent].
+ * If the component is a [ComponentSet], it delegates the retrieval to the [ComponentSet.getSetting] method.
+ * If the component is a [SettingsComponent] with a matching [SettingsEntry], it retrieves the value of the entry.
+ * If no value is found, the default value of the [SettingsEntry] is returned.
+ *
+ * @param entry The [SettingsEntry] that represents the configuration setting to be retrieved.
+ * @return The value associated with the provided [SettingsEntry], or the default value if no matching component is found.
+ *
+ * @author Fantamomo
+ * @since 1.0-SNAPSHOT
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> EventManagerComponent<*>.getSetting(entry: SettingsEntry<T>): T =
+    if (this is ComponentSet) getSetting(entry)
+    else (this as? SettingsComponent<T>)?.takeIf { it.entry === entry }?.value ?: entry.defaultValue


### PR DESCRIPTION
This pull request introduces significant enhancements and refactors to support configurable settings for parameter injection and event dispatching in the `EventManager`.

### Changes
- **Default Injectable Parameters**:
  - Documented default parameters (`manager`, `logger`, `scope`, `isWaiting`) in `README`.
  - Example added to showcase disabling specific injections.
  
- **Refactor `EventManager`**:
  - Removed the `defaultParameterInjection` flag.
  - Simplified `EventManager` initialization process.

- **Configurable Parameter Injection**:
  - Introduced settings-driven approach to manage injections for `manager`, `logger`, `scope`, and `isWaiting`.
  - Integrated `getSetting` utility for settings retrieval.

- **Settings Infrastructure**:
  - Added utility methods (`with` and `getSetting`) for managing and retrieving settings.
  - Introduced `SettingsComponent` for handling data storage and type-safe keys.
  - Added `SettingsEntry` and `LazySettingsEntry` classes for type-safe, lazy, default-initialized settings.

### Motivation
This update ensures flexibility in configuring parameter injections and event dispatch behavior, enabling developers to customize the behavior of the `EventManager` according to their requirements.