### PR TITLE
Add `DISPATCH_DEAD_EVENTS` setting to control event dispatching

### DIFF
--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -42,6 +42,8 @@ class DefaultEventManager internal constructor(
 
     private var isClosed = false
 
+    private val dispatchDeadEvents = components.getSetting(Settings.DISPATCH_DEAD_EVENTS)
+
     init {
         var components = components
         if (!components.getSetting(Settings.DISABLE_EVENTMANAGER_INJECTION)) components += ListenerParameterResolver.static(
@@ -244,7 +246,7 @@ class DefaultEventManager internal constructor(
             called = called or handlerList.call(event, genericTypes)
         }
 
-        if (!called && eventClass != DeadEvent::class) {
+        if (dispatchDeadEvents && !called && eventClass != DeadEvent::class) {
             dispatch(DeadEvent(event))
         }
     }
@@ -260,7 +262,7 @@ class DefaultEventManager internal constructor(
             called = called or handlerList.callSuspend(event, genericTypes)
         }
 
-        if (!called && eventClass != DeadEvent::class) {
+        if (dispatchDeadEvents && !called && eventClass != DeadEvent::class) {
             dispatchSuspend(DeadEvent(event))
         }
     }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/Settings.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/Settings.kt
@@ -42,6 +42,19 @@ object Settings {
      */
     val DISABLE_LOGGER_INJECTION by setting(false)
 
+    /**
+     * Configures whether dead events should be dispatched by the event manager.
+     *
+     * A dead event occurs when an event is posted to the event manager but no
+     * listener is registered to handle it. When this setting is enabled (`true`),
+     * the event manager dispatches such events as dead events, allowing specific
+     * listeners for dead events to handle them. If disabled (`false`), dead events
+     * are ignored and not dispatched.
+     *
+     * By default, this setting is enabled.
+     */
+    val DISPATCH_DEAD_EVENTS by setting(true)
+
 
     private inline fun <reified T> setting(name: String, defaultValue: T) = SettingsEntry<T>(name, defaultValue)
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
This pull request introduces a new configuration option, `DISPATCH_DEAD_EVENTS`, to control behavior related to the dispatching of `DeadEvent`.

- Added support for the `DISPATCH_DEAD_EVENTS` setting in the `DefaultEventManager`.
- Updated event handling logic to respect the `DISPATCH_DEAD_EVENTS` configuration.
- Improved the way suspended event handling is managed in relation to this setting.