### PR TITLE
Add SharedExclusiveExecution for handler execution control

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ configuration(event) {
 * `priority`: Determines handler execution order. Higher runs first.
 * `disallowSubtypes`: If `true`, only matches this exact event class.
 * `exclusiveListenerProcessing`: Prevents this handler from running concurrently. 
-This applies per EventManager instance — multiple managers may still invoke the handler concurrently.
+This applies per `SharedExclusiveExecution` instance.
 * `name`: Optional debug label for this method.
 * `silent`: If `true`, the handler will not prevent `DeadEvent` from being emitted.
 
@@ -506,13 +506,25 @@ class ServerListener : Listener {
 }
 ```
 
+You can add as many `ListenerParameterResolver` as you want, but only one `ExceptionHandler`.
+
+There is also a `SharedExclusiveExecution` component,
+which can be used to prevent concurrent execution of handlers, when the are using `exclusiveListenerProcessing`.
+Every EventManager has its own `SharedExclusiveExecution` instance,
+but you can override when adding it to the manager, via the `+` operator.
+
 If you want to combine some components:
 
 ```kotlin
-val manager = EventManager(SysOutExceptionHandler + parameter + dynamicParameter)
-```
+val sharedExecution = SharedExclusiveExecution()
 
-You can add as many `ListenerParameterResolver` as you want, but only one `ExceptionHandler`.
+val manager = EventManager(
+    SysOutExceptionHandler +
+            parameter +
+            dynamicParameter +
+            sharedExecution
+)
+```
 
 ## 🎓 How to Add to Your Project
 

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/components/SharedExclusiveExecution.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/components/SharedExclusiveExecution.kt
@@ -1,0 +1,56 @@
+package com.fantamomo.kevent.manager.components
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A component that supports shared-exclusive execution control for handlers.
+ *
+ * This class provides mechanisms to manage the concurrent execution of handlers
+ * using unique handler identifiers. Only one execution for a given handler ID
+ * can occur at a time, ensuring that tasks associated with the same handler ID
+ * do not overlap.
+ *
+ * @author Fantamomo
+ * @since 1.1-SNAPSHOT
+ */
+class SharedExclusiveExecution : EventManagerComponent<SharedExclusiveExecution> {
+    private val runningHandlers = ConcurrentHashMap<String, AtomicBoolean>()
+
+    /**
+     * Attempts to acquire the execution permission for the specified handler ID.
+     * Ensures that only one execution for the given handler ID can occur at a time.
+     *
+     * @param handlerId The unique identifier of the handler for which execution permission is requested.
+     * @return `true` if the permission is successfully acquired; `false` if it is already in use.
+     */
+    fun tryAcquire(handlerId: String): Boolean {
+        val flag = runningHandlers.computeIfAbsent(handlerId) { AtomicBoolean(false) }
+        return flag.compareAndSet(false, true)
+    }
+
+    /**
+     * Releases the execution lock for the specified handler ID, allowing it to be acquired again.
+     *
+     * This method sets the internal flag associated with the provided handler ID to `false`,
+     * indicating that the handler is no longer in use. It should be called after a handler has
+     * finished its execution to ensure other operations associated with the same handler ID
+     * can proceed.
+     *
+     * @param handlerId The unique identifier of the handler whose execution lock is to be released.
+     */
+    fun release(handlerId: String) {
+        runningHandlers[handlerId]?.set(false)
+    }
+
+    /**
+     * Clears references to handlers that are no longer valid.
+     */
+    fun clear() = runningHandlers.values.removeIf { !it.get() }
+
+    override val key = Key
+
+    companion object Key : EventManagerComponent.Key<SharedExclusiveExecution> {
+        override val clazz = SharedExclusiveExecution::class
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/factory.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/factory.kt
@@ -2,10 +2,7 @@
 
 package com.fantamomo.kevent.manager
 
-import com.fantamomo.kevent.manager.components.ComponentSet
-import com.fantamomo.kevent.manager.components.EventManagerComponent
-import com.fantamomo.kevent.manager.components.ExceptionHandler
-import com.fantamomo.kevent.manager.components.addIfAbsent
+import com.fantamomo.kevent.manager.components.*
 
 /**
  * Creates a default instance of [EventManager] with a predefined empty component set.
@@ -34,6 +31,8 @@ fun EventManager(): EventManager = EventManager(ComponentSet.of())
  * @since 1.0-SNAPSHOT
  */
 fun EventManager(components: EventManagerComponent<*>): EventManager {
-    val component = components.addIfAbsent(ExceptionHandler.Empty)
+    val component = components
+        .addIfAbsent(ExceptionHandler.Empty)
+        .addIfAbsent(SharedExclusiveExecution())
     return DefaultEventManager(component)
 }


### PR DESCRIPTION
This pull request introduces and integrates the `SharedExclusiveExecution` class to manage concurrent handler execution with unique identifiers. It includes the following updates:

- Adds `SharedExclusiveExecution` class, including methods to manage execution locks.
- Integrates `SharedExclusiveExecution` into `DefaultEventManager` for concurrent listener execution control, replacing the obsolete `isCurrentlyCalled` field.
- Updates the `EventManager` factory to include `SharedExclusiveExecution` as a default component.
- Updates the `README` documentation with usage details for `SharedExclusiveExecution`, including customization options and default behavior examples.