### PR TITLE
Refactor DefaultEventManager to emit DeadEvent correctly

### DIFF
--- a/k-event-manager/build.gradle.kts
+++ b/k-event-manager/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.1-SNAPSHOT"
+version = "1.2-SNAPSHOT"
 
 kotlin {
 

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -496,26 +496,28 @@ class DefaultEventManager internal constructor(
 
         abstract val handlerId: String
 
-        operator fun invoke(event: E) {
+        operator fun invoke(event: E): Boolean {
             if (configuration.getOrDefault(Key.EXCLUSIVE_LISTENER_PROCESSING)) {
-                if (!manager.sharedExclusiveExecution.tryAcquire(handlerId)) return
+                if (!manager.sharedExclusiveExecution.tryAcquire(handlerId)) return false
             }
             try {
                 method(event)
             } finally {
                 manager.sharedExclusiveExecution.release(handlerId)
             }
+            return true
         }
 
-        suspend fun invokeSuspend(event: E, isWaiting: Boolean) {
+        suspend fun invokeSuspend(event: E, isWaiting: Boolean): Boolean {
             if (configuration.getOrDefault(Key.EXCLUSIVE_LISTENER_PROCESSING)) {
-                if (!manager.sharedExclusiveExecution.tryAcquire(handlerId)) return
+                if (!manager.sharedExclusiveExecution.tryAcquire(handlerId)) return false
             }
             try {
                 invokeSuspendInternal(event, isWaiting)
             } finally {
                 manager.sharedExclusiveExecution.release(handlerId)
             }
+            return true
         }
 
         protected open suspend fun invokeSuspendInternal(event: E, isWaiting: Boolean) {}


### PR DESCRIPTION
This pull request:
- Modifies the `invoke` and `invokeSuspend` methods to return a `Boolean`, indicating the execution status and enhancing the handling of exclusive listeners.
- Refactors the `DefaultEventManager` to improve the handling of the `called` flag by ensuring correct updates for non-silent handlers and unifying logic across handler types.
- Updates the project version to `1.2-SNAPSHOT` in `k-event-manager`.