### PR TITLE
Add support for suspendable event listeners and handlers

### DIFF
--- a/k-event-manager/build.gradle.kts
+++ b/k-event-manager/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.2-SNAPSHOT"
+version = "1.3-SNAPSHOT"
 
 kotlin {
 

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/HandlerEventScope.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/HandlerEventScope.kt
@@ -62,6 +62,27 @@ interface HandlerEventScope {
     ): RegisteredLambdaHandler
 
     /**
+     * Registers a suspendable event handler with the event system.
+     *
+     * This method allows for asynchronous handler registration for a specific type of event.
+     * The handler will be invoked whenever an instance of the specified event class is dispatched.
+     * Additionally, a custom event configuration can be provided to modify event-specific behavior.
+     *
+     * @param E The type of event the handler will process. It must extend from [Dispatchable].
+     * @param event The class of the event to register the handler for.
+     * @param configuration The configuration for the event handler. Defaults to the result of [EventConfiguration.default].
+     * @param handler The suspending function to be invoked when the event is dispatched.
+     * @return An instance of [RegisteredLambdaHandler] that can be used to unregister the handler.
+     *
+     * @since 1.3-SNAPSHOT
+     */
+    fun <E : Dispatchable> registerSuspend(
+        event: KClass<E>,
+        configuration: EventConfiguration<E> = EventConfiguration.default(),
+        handler: suspend (E) -> Unit,
+    ): RegisteredLambdaHandler
+
+    /**
      * Closes the `HandlerEventScope` and unregister its handlers.
      *
      * Once closed, the scope cannot be reused, and all

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/internal/HandlerEventScopeImpl.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/internal/HandlerEventScopeImpl.kt
@@ -47,6 +47,15 @@ class HandlerEventScopeImpl(val parent: HandlerEventScope) : HandlerEventScope {
         return parent.register(event, configuration, handler).also { lambdas.add(it) }
     }
 
+    override fun <E : Dispatchable> registerSuspend(
+        event: KClass<E>,
+        configuration: EventConfiguration<E>,
+        handler: suspend (E) -> Unit,
+    ): RegisteredLambdaHandler {
+        checkClosed()
+        return parent.registerSuspend(event, configuration, handler).also { lambdas.add(it) }
+    }
+
     override fun close() {
         checkClosed()
         isClosed = true


### PR DESCRIPTION
This pull request introduces support for suspendable event listeners and handlers, enhancing the capability to register and manage asynchronous event handling.

#### Changes:
- **`HandlerEventScope`**:
    - Added `registerSuspend` for asynchronous event registration and specific handler configuration.
- **`DefaultEventManager`**: 
  - Added `registerSuspend` method for suspendable event listener registration.
  - Introduced `RegisteredSuspendFunctionListener` for handling suspend functions.
  - Improved error handling and included suspend listener details in handler descriptions.