### PR TITLE
Add sticky event handling and dispatch configurations

### DIFF
--- a/k-event-manager/build.gradle.kts
+++ b/k-event-manager/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.8-SNAPSHOT"
+version = "1.9-SNAPSHOT"
 
 kotlin {
 

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -390,6 +390,16 @@ class DefaultEventManager internal constructor(
         }
     }
 
+    override fun clearStickyEvents() {
+        checkClosed()
+        stickyEvents.clear()
+    }
+
+    override fun removeStickyEvent(clazz: KClass<out Dispatchable>) {
+        checkClosed()
+        stickyEvents.remove(clazz)
+    }
+
     override fun <E : Dispatchable> register(
         event: KClass<E>,
         configuration: EventConfiguration<E>,
@@ -448,6 +458,7 @@ class DefaultEventManager internal constructor(
         isClosed = true
         handlers.forEach { it.value.close() }
         handlers.clear()
+        stickyEvents.clear()
         scope.cancel()
         sharedExclusiveExecution.clear()
     }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
@@ -2,6 +2,7 @@ package com.fantamomo.kevent.manager
 
 import com.fantamomo.kevent.Dispatchable
 import com.fantamomo.kevent.manager.config.DispatchConfig
+import kotlin.reflect.KClass
 
 /**
  * Interface for managing event listeners and dispatching events in the event system.
@@ -21,7 +22,12 @@ interface EventManager : HandlerEventScope {
      * to the event type or any of its supertypes. The event is processed synchronously,
      * ensuring that each listener is invoked before continuing execution.
      *
+     * The optional [config] parameter allows fine-grained control over the dispatch process,
+     * such as marking the event as sticky or disable firing a [com.fantamomo.kevent.DeadEvent] when no listeners are found.
+     * If not provided, [DispatchConfig.EMPTY] is used as the default.
+     *
      * @param event The event instance to be dispatched to the appropriate listeners.
+     * @param config Configuration options for dispatching the event (e.g., sticky flag, DeadEvent behavior).
      */
     fun dispatch(event: Dispatchable, config: DispatchConfig = DispatchConfig.EMPTY)
 
@@ -33,7 +39,24 @@ interface EventManager : HandlerEventScope {
      * counterpart, this method allows asynchronous processing within a coroutine
      * context, enabling non-blocking or delayed execution of event handling logic.
      *
+     * The optional [config] parameter allows fine-grained control over the dispatch process,
+     * such as marking the event as sticky or disable firing a [com.fantamomo.kevent.DeadEvent] when no listeners are found.
+     * If not provided, [DispatchConfig.EMPTY] is used as the default.
+     *
      * @param event The event instance to be dispatched to the appropriate listeners.
+     * @param config Configuration options for dispatching the event (e.g., sticky flag, DeadEvent behavior).
      */
     suspend fun dispatchSuspend(event: Dispatchable, config: DispatchConfig = DispatchConfig.EMPTY)
+
+    /**
+     * Clears all sticky events stored in the event manager.
+     */
+    fun clearStickyEvents()
+
+    /**
+     * Removes a stored sticky event associated with the specified event type.
+     *
+     * @param clazz The class type of the sticky event to be removed. It must extend [Dispatchable].
+     */
+    fun removeStickyEvent(clazz: KClass<out Dispatchable>)
 }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
@@ -1,6 +1,7 @@
 package com.fantamomo.kevent.manager
 
 import com.fantamomo.kevent.Dispatchable
+import com.fantamomo.kevent.manager.config.DispatchConfig
 
 /**
  * Interface for managing event listeners and dispatching events in the event system.
@@ -22,7 +23,7 @@ interface EventManager : HandlerEventScope {
      *
      * @param event The event instance to be dispatched to the appropriate listeners.
      */
-    fun dispatch(event: Dispatchable)
+    fun dispatch(event: Dispatchable, config: DispatchConfig = DispatchConfig.EMPTY)
 
     /**
      * Dispatches an event to all registered event listeners asynchronously.
@@ -34,5 +35,5 @@ interface EventManager : HandlerEventScope {
      *
      * @param event The event instance to be dispatched to the appropriate listeners.
      */
-    suspend fun dispatchSuspend(event: Dispatchable)
+    suspend fun dispatchSuspend(event: Dispatchable, config: DispatchConfig = DispatchConfig.EMPTY)
 }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
@@ -1,0 +1,19 @@
+package com.fantamomo.kevent.manager.config
+
+class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
+
+    @Suppress("UNCHECKED_CAST")
+    operator fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T?
+
+    fun <T> getOrDefault(key: DispatchConfigKey<T>) = get(key) ?: key.defaultValue
+
+    operator fun <T> contains(key: DispatchConfigKey<T>) = key in data
+
+    operator fun <T> contains(value: T) = value in data.values
+
+    companion object {
+        val EMPTY = DispatchConfig(emptyMap())
+
+        operator fun invoke(scope: DispatchConfigScope) = if (scope.data.isEmpty()) EMPTY else DispatchConfig(scope.data)
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
@@ -7,6 +7,8 @@ class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
 
     fun <T> getOrDefault(key: DispatchConfigKey<T>) = get(key) ?: key.defaultValue
 
+    fun <T> getOrDefault(key: DispatchConfigKey<T>, default: T) = get(key) ?: default
+
     operator fun <T> contains(key: DispatchConfigKey<T>) = key in data
 
     operator fun <T> contains(value: T) = value in data.values

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
@@ -1,21 +1,78 @@
 package com.fantamomo.kevent.manager.config
 
+/**
+ * Represents a configuration for event dispatching.
+ *
+ * @constructor Creates a DispatchConfig instance with a defined set of configuration data.
+ * @param data A map of configuration keys and their corresponding values.
+ *
+ * @author Fantamomo
+ * @since 1.9-SNAPSHOT
+ */
 class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
 
+    /**
+     * Retrieves the value associated with the specified [DispatchConfigKey] in the configuration.
+     * If the key is not found or the value cannot be cast to the expected type, `null` is returned.
+     *
+     * @param key The configuration key whose associated value is to be retrieved.
+     * @return The value associated with the key, or `null` if the key is not present or type conversion fails.
+     */
     @Suppress("UNCHECKED_CAST")
     operator fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T?
 
+    /**
+     * Retrieves the value associated with the specified [DispatchConfigKey] in the configuration.
+     * Returns the key's default value if the key is not present or its value is null.
+     *
+     * @param key The configuration key whose associated value is to be retrieved or whose default value should be used.
+     * @return The value associated with the key, or the key's default value if no value exists.
+     */
     fun <T> getOrDefault(key: DispatchConfigKey<T>) = get(key) ?: key.defaultValue
 
+    /**
+     * Retrieves the value associated with the specified key in the configuration.
+     * If the key is not found or its value is null, the provided default value is returned.
+     *
+     * @param key The configuration key whose associated value is to be retrieved.
+     * @param default The value to return if the key is not present or its value is null.
+     * @return The value associated with the key, or the provided default value if no value exists.
+     */
     fun <T> getOrDefault(key: DispatchConfigKey<T>, default: T) = get(key) ?: default
 
+    /**
+     * Checks whether the specified configuration key is present in the data map.
+     *
+     * @param key The [DispatchConfigKey] to check for existence in the configuration data.
+     * @return `true` if the key exists in the configuration data, otherwise `false`.
+     */
     operator fun <T> contains(key: DispatchConfigKey<T>) = key in data
 
+    /**
+     * Checks whether the specified value exists in the configuration data.
+     *
+     * @param value The value to check for existence in the configuration data.
+     * @return `true` if the value exists in the configuration data, otherwise `false`.
+     */
     operator fun <T> contains(value: T) = value in data.values
 
     companion object {
+        /**
+         * Represents an empty [DispatchConfig] instance.
+         *
+         * This constant is intended for usage where a default or empty configuration
+         * is required in dispatching events. It is initialized with an empty data map,
+         * ensuring no configuration values are preset.
+         */
         val EMPTY = DispatchConfig(emptyMap())
 
+        /**
+         * Produces a `DispatchConfig` instance based on the provided [scope].
+         * If the [scope]'s data is empty, a predefined empty configuration is returned.
+         *
+         * @param scope The [DispatchConfigScope] containing configuration data used to
+         *              initialize a new `DispatchConfig` instance.
+         */
         operator fun invoke(scope: DispatchConfigScope) = if (scope.data.isEmpty()) EMPTY else DispatchConfig(scope.data)
     }
 }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigKey.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigKey.kt
@@ -1,0 +1,10 @@
+package com.fantamomo.kevent.manager.config
+
+data class DispatchConfigKey<T>(val name: String, val defaultValue: T) {
+    companion object {
+        val DISPATCH_DEAD_EVENT = key("dispatch_dead_event", true)
+        val STICKY = key("sticky", false)
+
+        private fun <T> key(name: String, defaultValue: T) = DispatchConfigKey(name, defaultValue)
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigKey.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigKey.kt
@@ -1,8 +1,44 @@
 package com.fantamomo.kevent.manager.config
 
+/**
+ * Represents a configuration key used in the event dispatching mechanism.
+ *
+ * @param T The type of the value associated with the configuration key.
+ * @param name The name of the configuration key, uniquely identifying its purpose.
+ * @param defaultValue The default value assigned to the configuration key if no other value is specified.
+ *
+ * This class is used in conjunction with [DispatchConfig] and [DispatchConfigScope] to define and manage
+ * configuration options for event dispatching. The key provides a way to define settings with an associated
+ * type and default value, ensuring type-safety and clear defaults throughout the framework.
+ *
+ * @author Fantamomo
+ * @since 1.9-SNAPSHOT
+ */
 data class DispatchConfigKey<T>(val name: String, val defaultValue: T) {
     companion object {
+        /**
+         * A predefined configuration key that enables or disables the dispatching of [com.fantamomo.kevent.DeadEvent].
+         *
+         * [com.fantamomo.kevent.DeadEvent] are events that are posted to the event dispatching mechanism but do not
+         * have any registered listeners to handle them. When this flag is set to `true`, the
+         * system allows dispatching these events, enabling the possibility of catching and
+         * analyzing unhandled events.
+         *
+         * The default value for this configuration key is `true`, which means dispatching
+         * dead events is permitted unless explicitly disabled.
+         * @see com.fantamomo.kevent.DeadEvent
+         */
         val DISPATCH_DEAD_EVENT = key("dispatch_dead_event", true)
+        /**
+         * A predefined configuration key that determines whether events are dispatched as "sticky."
+         *
+         * Sticky events remain cached in the event bus and are immediately delivered
+         * to new listeners when they register, ensuring that they receive the most recent
+         * instance of the event even if it was dispatched prior to their registration.
+         *
+         * The default value for this configuration key is `false`, meaning events are not
+         * cached and only delivered to active listeners at the time of dispatch unless explicitly enabled.
+         */
         val STICKY = key("sticky", false)
 
         private fun <T> key(name: String, defaultValue: T) = DispatchConfigKey(name, defaultValue)

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
@@ -1,23 +1,99 @@
 package com.fantamomo.kevent.manager.config
 
+import com.fantamomo.kevent.EventDsl
+
+/**
+ * Provides a scope for configuring event dispatch settings using a type-safe DSL.
+ *
+ * This class is used in conjunction with [DispatchConfig] and [DispatchConfigKey] to
+ * define and manage configuration options for event dispatching in a flexible and
+ * type-safe manner. The [DispatchConfigScope] enables storing, retrieving, and modifying
+ * configuration values through a set of operations.
+ *
+ * This class is annotated with the [EventDsl] marker to enforce proper scoping rules
+ * when used within a DSL context.
+ *
+ * @author Fantamomo
+ * @since 1.9-SNAPSHOT
+ */
+@EventDsl
 class DispatchConfigScope {
+    /**
+     * A mutable map that stores configuration data for event dispatching.
+     */
     internal val data = mutableMapOf<DispatchConfigKey<*>, Any?>()
 
+    /**
+     * Sets the value associated with a specified [DispatchConfigKey] in the configuration data.
+     *
+     * @param key The configuration key for which the value should be set.
+     * @param value The value to associate with the specified key.
+     * @param T The type of the value associated with the configuration key.
+     */
     operator fun <T> set(key: DispatchConfigKey<T>, value: T) {
         data[key] = value
     }
 
+    /**
+     * Retrieves the value associated with the specified [DispatchConfigKey] from the configuration data.
+     * If the key is not found or the value cannot be cast to the expected type, `null` is returned.
+     *
+     * @param key The configuration key whose associated value is to be retrieved.
+     * @return The value associated with the specified key, or `null` if the key is not present
+     *         or the value cannot be cast to the expected type.
+     */
     @Suppress("UNCHECKED_CAST")
     operator fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T?
 
+    /**
+     * Retrieves the value associated with the specified [DispatchConfigKey] in the configuration.
+     * If the key is not found or its value is null, the provided default value is returned.
+     *
+     * @param key The configuration key whose associated value is to be retrieved or whose
+     * default value should be used if no value is present.
+     * @param default The default value to return if the key is not present or its value is null.
+     * @return The value associated with the specified key, or the provided default value
+     * if no value exists.
+     * @param T The type of the value associated with the configuration key.
+     */
     fun <T> getOrDefault(key: DispatchConfigKey<T>, default: T) = get(key) ?: default
 
+    /**
+     * Retrieves the value associated with the specified configuration key or returns its default value
+     * if the key is not present in the configuration or its value is null.
+     *
+     * @param key The configuration key whose associated value is to be retrieved.
+     *            The key includes a default value, which will be returned if no other value is present
+     *            or the associated value is null.
+     * @return The value associated with the specified key, or the default value if the key's value is
+     *         absent or null.
+     * @param T The type of the value associated with the configuration key.
+     */
     fun <T> getOrDefault(key: DispatchConfigKey<T>) = get(key) ?: key.defaultValue
 
+    /**
+     * Checks whether the specified [DispatchConfigKey] is present in the configuration data.
+     *
+     * @param key The configuration key to check for existence in the configuration data.
+     * @return `true` if the key exists in the configuration data, otherwise `false`.
+     * @param T The type of the value associated with the configuration key.
+     */
     operator fun <T> contains(key: DispatchConfigKey<T>) = key in data
 
+    /**
+     * Checks whether the specified value exists in the configuration data.
+     *
+     * @param value The value to check for existence in the configuration data.
+     * @return `true` if the value exists in the configuration data, otherwise `false`.
+     */
     operator fun <T> contains(value: T) = value in data.values
 
+    /**
+     * Removes the value associated with the specified [DispatchConfigKey] from the configuration data.
+     *
+     * @param key The configuration key whose associated value should be removed.
+     * @param T The type of the value associated with the configuration key.
+     */
     fun <T> remove(key: DispatchConfigKey<T>) {
         data.remove(key)
     }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
@@ -1,0 +1,22 @@
+package com.fantamomo.kevent.manager.config
+
+class DispatchConfigScope {
+    internal val data = mutableMapOf<DispatchConfigKey<*>, Any?>()
+
+    operator fun <T> set(key: DispatchConfigKey<T>, value: T) {
+        data[key] = value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    operator fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T?
+
+    fun <T> getOrDefault(key: DispatchConfigKey<T>) = get(key) ?: key.defaultValue
+
+    operator fun <T> contains(key: DispatchConfigKey<T>) = key in data
+
+    operator fun <T> contains(value: T) = value in data.values
+
+    fun <T> remove(key: DispatchConfigKey<T>) {
+        data.remove(key)
+    }
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
@@ -10,6 +10,8 @@ class DispatchConfigScope {
     @Suppress("UNCHECKED_CAST")
     operator fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T?
 
+    fun <T> getOrDefault(key: DispatchConfigKey<T>, default: T) = get(key) ?: default
+
     fun <T> getOrDefault(key: DispatchConfigKey<T>) = get(key) ?: key.defaultValue
 
     operator fun <T> contains(key: DispatchConfigKey<T>) = key in data

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/keys.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/keys.kt
@@ -1,0 +1,9 @@
+package com.fantamomo.kevent.manager.config
+
+var DispatchConfigScope.dispatchDeadEvent: Boolean
+    get() = getOrDefault(DispatchConfigKey.DISPATCH_DEAD_EVENT)
+    set(value) = set(DispatchConfigKey.DISPATCH_DEAD_EVENT, value)
+
+var DispatchConfigScope.sticky: Boolean
+    get() = getOrDefault(DispatchConfigKey.STICKY)
+    set(value) = set(DispatchConfigKey.STICKY, value)

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/keys.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/keys.kt
@@ -1,9 +1,37 @@
 package com.fantamomo.kevent.manager.config
 
+/**
+ * Specifies whether to dispatch [com.fantamomo.kevent.DeadEvent].
+ *
+ * If set to `true`, dead events will be dispatched and handled accordingly.
+ * If set to `false`, they will not be dispatched.
+ *
+ * This property interacts with the underlying configuration within the [DispatchConfigScope],
+ * leveraging [DispatchConfigKey.DISPATCH_DEAD_EVENT] to store and retrieve its value.
+ *
+ * The default value is determined by the configuration key's predefined default.
+ *
+ * @author Fantamomo
+ * @since 1.9-SNAPSHOT
+ */
 var DispatchConfigScope.dispatchDeadEvent: Boolean
     get() = getOrDefault(DispatchConfigKey.DISPATCH_DEAD_EVENT)
     set(value) = set(DispatchConfigKey.DISPATCH_DEAD_EVENT, value)
 
+/**
+ * Represents a configuration property within the [DispatchConfigScope] that determines
+ * if event dispatch behavior is persistent or non-persistent.
+ *
+ * When `true`, the "sticky" behavior for event dispatching is enabled, allowing events
+ * to be retained and dispatched to listeners that subscribe after the event occurs.
+ * When `false`, only currently active listeners will receive dispatched events.
+ *
+ * This property uses the [DispatchConfigKey.STICKY] key to store and retrieve its value.
+ * The default value is determined by the dispatch configuration setup.
+ *
+ * @author Fantamomo
+ * @since 1.9-SNAPSHOT
+ */
 var DispatchConfigScope.sticky: Boolean
     get() = getOrDefault(DispatchConfigKey.STICKY)
     set(value) = set(DispatchConfigKey.STICKY, value)

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/dispatch.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/dispatch.kt
@@ -1,0 +1,42 @@
+package com.fantamomo.kevent.manager
+
+import com.fantamomo.kevent.Dispatchable
+import com.fantamomo.kevent.manager.config.DispatchConfig
+import com.fantamomo.kevent.manager.config.DispatchConfigScope
+
+/**
+ * Dispatches an event to all registered listeners with a configurable dispatch scope.
+ *
+ * This inline function provides a way to dispatch an event of type [E], along with a configurable
+ * [DispatchConfigScope]. Use the [config] lambda to define custom behavior or configuration
+ * for the event dispatch process.
+ *
+ * @param event The event instance to be dispatched. Must be a subtype of [Dispatchable].
+ * @param config A lambda function used to configure the [DispatchConfigScope] for the event dispatch.
+ * @since 1.9-SNAPSHOT
+ * @author Fantamomo
+ */
+inline fun <E : Dispatchable> EventManager.dispatch(event: E, config: DispatchConfigScope.() -> Unit) {
+    val scope = DispatchConfigScope()
+    scope.config()
+    dispatch(event, DispatchConfig(scope))
+}
+
+/**
+ * Asynchronously dispatches a specified event to all registered listeners with a custom configuration.
+ *
+ * This inline function provides a way to dispatch an event of type [E], along with a configurable
+ * [DispatchConfigScope]. Use the [config] lambda to define custom behavior or configuration
+ * for the event dispatch process.
+ *
+ * @param E The type of the event, which must extend [Dispatchable].
+ * @param event The event instance to be dispatched to all applicable listeners.
+ * @param config A lambda function to configure the dispatch behavior using a [DispatchConfigScope].
+ * @since 1.9-SNAPSHOT
+ * @author Fantamomo
+ */
+suspend inline fun <E : Dispatchable> EventManager.dispatchSuspend(event: E, config: DispatchConfigScope.() -> Unit) {
+    val scope = DispatchConfigScope()
+    scope.config()
+    dispatchSuspend(event, DispatchConfig(scope))
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/Settings.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/settings/Settings.kt
@@ -17,6 +17,18 @@ object Settings {
      * `true` will turn off this behavior.
      */
     val DISABLE_IS_WAITING_INJECTION by setting(false)
+
+    /**
+     * A setting that disables the injection of the `isSticky:` [Boolean] state into parameter resolution during
+     * event dispatching.
+     *
+     * By default, the value is `false`, meaning the `isSticky` injection is enabled. Setting this to
+     * `true` will turn off this behavior.
+     *
+     * @since 1.9-SNAPSHOT
+     */
+    val DISABLE_IS_STICKY_INJECTION by setting(false)
+
     /**
      * A setting that disables the injection of the `manager:` [com.fantamomo.kevent.manager.EventManager] state into parameter resolution during
      * event dispatching.
@@ -25,6 +37,7 @@ object Settings {
      * `true` will turn off this behavior.
      */
     val DISABLE_EVENTMANAGER_INJECTION by setting(false)
+
     /**
      * A setting that disables the injection of the `scope:` [kotlinx.coroutines.CoroutineScope] state into parameter resolution during
      * event dispatching.
@@ -33,6 +46,7 @@ object Settings {
      * `true` will turn off this behavior.
      */
     val DISABLE_SCOPE_INJECTION by setting(false)
+
     /**
      * A setting that disables the injection of the `logger:` [java.util.logging.Logger] state into parameter resolution during
      * event dispatching.
@@ -66,6 +80,8 @@ object Settings {
 
 
     private inline fun <reified T> setting(name: String, defaultValue: T) = SettingsEntry<T>(name, defaultValue)
+
     @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T> setting(defaultValue: T) = LazySettingsEntry(T::class as KClass<T & Any>, defaultValue)
+    private inline fun <reified T> setting(defaultValue: T) =
+        LazySettingsEntry(T::class as KClass<T & Any>, defaultValue)
 }


### PR DESCRIPTION
This pull request introduces enhanced sticky event handling and dispatch configuration capabilities. Key updates include:

- **Sticky Event Support**:
  - Implementation of `stickyEvents` to store and manage sticky events.
  - Enhancements to `dispatch` and `dispatchSuspend` methods to use sticky event processing via `DispatchConfig`.
  - Addition of `dispatchSticky` to push sticky events to listeners upon registration.
  - Introduction of cleanup methods: `clearStickyEvents` and `removeStickyEvent` (by class type).
  - Automatic sticky event cleanup on manager closure.

- **Dispatch Configuration**:
  - Introduction of `DispatchConfig` and `DispatchConfigScope` for advanced configuration management.
  - New configuration keys: `DISPATCH_DEAD_EVENT` and `STICKY`.
  - Added the ability to customize event dispatch behavior using `dispatchDeadEvent` and `sticky` properties.
  - New `getOrDefault` overload for customizable default value resolution.
  - Support for inline configuration in `dispatch` and `dispatchSuspend` functions.

- **Documentation**:
  - Comprehensive KDoc added for new classes, methods, properties, and configuration constants.

- **Additional Features**:
  - A new setting `DISABLE_IS_STICKY_INJECTION` to disable sticky parameter injection.
  - Introduction of `IsStickyParameterResolver` and `StickyStrategy` for improved parameter handling during event dispatch.