### PR TITLE
Add type safety and enhancements to dispatch and configuration APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ There are 5 default injectable parameter:
   - when called with `dispatch` it is `false`
   - when called with `dispatchSuspend` it is `true`
 - `config: EventConfiguration<*>`: The configuration of the handler.
+- `isSticky: Boolean`: If the event is sticky. See [Sticky Events](#sticky-events).
 
 The following example disables `scope` and `logger`:
 
@@ -461,6 +462,34 @@ only `onMyEvent` is called.
 > the event manager currently **cannot** verify the generic type in this inheritance case.  
 > This means the listener for the parent event might still be called even if the generic type does not match.  
 > A solution for this is being worked on.
+
+---
+
+## Sticky Events
+
+A **sticky event** is an event stored in the manager and automatically delivered to all **newly registered** listeners.
+
+To mark an event as *sticky*, set the `sticky` property in the `DispatchConfig` class to `true`:
+
+```kotlin
+manager.dispatch(MyEvent(...)) {
+    sticky = true
+}
+
+// or
+
+val config = createDispatchConfig {
+    sticky = true
+}
+
+manager.dispatch(MyEvent(...), config)
+```
+
+When a new listener is registered, it will immediately receive the stored event.
+
+> Only the **most recent** sticky event of a given type is kept.
+
+There is also a new injectable parameter `isSticky: Boolean` that can be used to check whether an event is sticky.
 
 ---
 

--- a/k-event-manager/build.gradle.kts
+++ b/k-event-manager/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.9-SNAPSHOT"
+version = "1.10-SNAPSHOT"
 
 kotlin {
 

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/DefaultEventManager.kt
@@ -349,7 +349,7 @@ class DefaultEventManager internal constructor(
         }
     }
 
-    override fun dispatch(event: Dispatchable, config: DispatchConfig) {
+    override fun <D : Dispatchable> dispatch(event: D, config: DispatchConfig<D>) {
         checkClosed()
         if (handlers.isEmpty()) return
         val eventClass = event::class
@@ -370,7 +370,7 @@ class DefaultEventManager internal constructor(
         }
     }
 
-    override suspend fun dispatchSuspend(event: Dispatchable, config: DispatchConfig) {
+    override suspend fun <D : Dispatchable> dispatchSuspend(event: D, config: DispatchConfig<D>) {
         checkClosed()
         val eventClass = event::class
         var called = false

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/EventManager.kt
@@ -29,7 +29,7 @@ interface EventManager : HandlerEventScope {
      * @param event The event instance to be dispatched to the appropriate listeners.
      * @param config Configuration options for dispatching the event (e.g., sticky flag, DeadEvent behavior).
      */
-    fun dispatch(event: Dispatchable, config: DispatchConfig = DispatchConfig.EMPTY)
+    fun <D : Dispatchable> dispatch(event: D, config: DispatchConfig<D> = DispatchConfig.empty())
 
     /**
      * Dispatches an event to all registered event listeners asynchronously.
@@ -46,7 +46,7 @@ interface EventManager : HandlerEventScope {
      * @param event The event instance to be dispatched to the appropriate listeners.
      * @param config Configuration options for dispatching the event (e.g., sticky flag, DeadEvent behavior).
      */
-    suspend fun dispatchSuspend(event: Dispatchable, config: DispatchConfig = DispatchConfig.EMPTY)
+    suspend fun <D : Dispatchable> dispatchSuspend(event: D, config: DispatchConfig<D> = DispatchConfig.empty())
 
     /**
      * Clears all sticky events stored in the event manager.

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfig.kt
@@ -1,15 +1,34 @@
 package com.fantamomo.kevent.manager.config
 
+import com.fantamomo.kevent.Dispatchable
+
 /**
- * Represents a configuration for event dispatching.
+ * Represents the configuration storage used within the dispatch system.
  *
- * @constructor Creates a DispatchConfig instance with a defined set of configuration data.
- * @param data A map of configuration keys and their corresponding values.
+ * The [DispatchConfig] interface defines the contract for accessing and managing configuration
+ * data specific to dispatchable events. It ensures type-safe retrieval of configuration values
+ * and provides utility methods for common operations like checking for key existence and
+ * determining if the configuration is empty.
+ *
+ * The configuration keys are represented by instances of [DispatchConfigKey] associated with
+ * specific types. This allows for strongly-typed lookups and default value management.
+ *
+ * @param E The type of [Dispatchable] events associated with this configuration.
  *
  * @author Fantamomo
  * @since 1.9-SNAPSHOT
  */
-class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
+sealed interface DispatchConfig<E : Dispatchable> {
+    /**
+     * Represents the number of entries in the configuration data map.
+     *
+     * This property indicates the total count of key-value pairs currently held
+     * within the configuration. It provides a way to monitor or validate the
+     * amount of configuration data managed by the [DispatchConfig].
+     *
+     * @since 1.10-SNAPSHOT
+     */
+    val size: Int
 
     /**
      * Retrieves the value associated with the specified [DispatchConfigKey] in the configuration.
@@ -19,7 +38,7 @@ class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
      * @return The value associated with the key, or `null` if the key is not present or type conversion fails.
      */
     @Suppress("UNCHECKED_CAST")
-    operator fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T?
+    operator fun <T> get(key: DispatchConfigKey<T>): T?
 
     /**
      * Retrieves the value associated with the specified [DispatchConfigKey] in the configuration.
@@ -46,7 +65,7 @@ class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
      * @param key The [DispatchConfigKey] to check for existence in the configuration data.
      * @return `true` if the key exists in the configuration data, otherwise `false`.
      */
-    operator fun <T> contains(key: DispatchConfigKey<T>) = key in data
+    operator fun <T> contains(key: DispatchConfigKey<T>): Boolean
 
     /**
      * Checks whether the specified value exists in the configuration data.
@@ -54,17 +73,20 @@ class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
      * @param value The value to check for existence in the configuration data.
      * @return `true` if the value exists in the configuration data, otherwise `false`.
      */
-    operator fun <T> contains(value: T) = value in data.values
+    operator fun <T> contains(value: T): Boolean
 
-    companion object {
-        /**
-         * Represents an empty [DispatchConfig] instance.
-         *
-         * This constant is intended for usage where a default or empty configuration
-         * is required in dispatching events. It is initialized with an empty data map,
-         * ensuring no configuration values are preset.
-         */
-        val EMPTY = DispatchConfig(emptyMap())
+    /**
+     * Determines if the configuration is empty.
+     *
+     * This method checks whether the configuration data contains any entries.
+     *
+     * @return `true` if the configuration has no entries, `false` otherwise.
+     *
+     * @since 1.10-SNAPSHOT
+     */
+    fun isEmpty(): Boolean
+
+    companion object Empty : DispatchConfig<Nothing> {
 
         /**
          * Produces a `DispatchConfig` instance based on the provided [scope].
@@ -73,6 +95,72 @@ class DispatchConfig(private val data: Map<DispatchConfigKey<*>, Any?>) {
          * @param scope The [DispatchConfigScope] containing configuration data used to
          *              initialize a new `DispatchConfig` instance.
          */
-        operator fun invoke(scope: DispatchConfigScope) = if (scope.data.isEmpty()) EMPTY else DispatchConfig(scope.data)
+        operator fun <E : Dispatchable> invoke(scope: DispatchConfigScope<E>): DispatchConfig<E> =
+            (if (scope.data.isEmpty()) empty() else DispatchConfigImpl(scope.data))
+
+        /**
+         * Returns the current instance of `DispatchConfig` casted to a version parameterized with the
+         * generic type [E].
+         *
+         * @param E The type of `Dispatchable` event associated with the configuration.
+         *
+         * @since 1.10-SNAPSHOT
+         */
+        @Suppress("UNCHECKED_CAST")
+        fun <E : Dispatchable> empty() = this as DispatchConfig<E>
+
+        override val size: Int = 0
+
+        override fun <T> get(key: DispatchConfigKey<T>) = null
+
+        override fun <T> getOrDefault(key: DispatchConfigKey<T>) = key.defaultValue
+
+        override fun <T> getOrDefault(key: DispatchConfigKey<T>, default: T) = default
+
+        override fun <T> contains(key: DispatchConfigKey<T>) = false
+
+        override fun <T> contains(value: T) = false
+        override fun isEmpty() = true
+    }
+
+    /**
+     * Implementation of the [DispatchConfig] interface that provides a mechanism to store
+     * and retrieve configuration data for dispatchable events.
+     *
+     * This class encapsulates a map of configuration keys and their associated values,
+     * ensuring type safety and efficient access to specific configurations.
+     *
+     * @param E The type of dispatchable entity this configuration applies to.
+     * @constructor Internal constructor for creating an instance of [DispatchConfigImpl].
+     * @property data The internal map storing configuration keys and their associated values.
+     *
+     * @since 1.10-SNAPSHOT
+     * @author Fantamomo
+     */
+    class DispatchConfigImpl<E : Dispatchable> internal constructor(private val data: Map<DispatchConfigKey<*>, Any?>) :
+        DispatchConfig<E> {
+        override val size: Int
+            get() = data.size
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> get(key: DispatchConfigKey<T>): T? = data[key] as? T
+
+        override fun <T> contains(key: DispatchConfigKey<T>) = data.containsKey(key)
+
+        override fun <T> contains(value: T) = data.containsValue(value)
+
+        override fun isEmpty() = data.isEmpty()
+
+        /**
+         * Converts the internal immutable configuration data map into a mutable map.
+         *
+         * This method is intended for internal use when modifications to the configuration
+         * data are necessary. It creates and returns a mutable copy of the existing data map,
+         * ensuring that the original immutable map remains unchanged.
+         *
+         * @return A mutable map containing the same entries as the internal immutable data map.
+         */
+        @PublishedApi
+        internal fun dataAsMutable() = data.toMutableMap()
     }
 }

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/DispatchConfigScope.kt
@@ -1,5 +1,6 @@
 package com.fantamomo.kevent.manager.config
 
+import com.fantamomo.kevent.Dispatchable
 import com.fantamomo.kevent.EventDsl
 
 /**
@@ -17,11 +18,13 @@ import com.fantamomo.kevent.EventDsl
  * @since 1.9-SNAPSHOT
  */
 @EventDsl
-class DispatchConfigScope {
+class DispatchConfigScope<E : Dispatchable> @PublishedApi internal constructor(internal val data: MutableMap<DispatchConfigKey<*>, Any?>) {
+
     /**
-     * A mutable map that stores configuration data for event dispatching.
+     * Creates a new instance of `DispatchConfigScope` with an empty mutable map
+     * as the initial configuration data.
      */
-    internal val data = mutableMapOf<DispatchConfigKey<*>, Any?>()
+    constructor() : this(mutableMapOf())
 
     /**
      * Sets the value associated with a specified [DispatchConfigKey] in the configuration data.

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/config.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/config.kt
@@ -1,0 +1,49 @@
+package com.fantamomo.kevent.manager.config
+
+import com.fantamomo.kevent.Dispatchable
+import com.fantamomo.kevent.manager.config.DispatchConfig.DispatchConfigImpl
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Modifies the current [DispatchConfig] using the provided DSL [block].
+ *
+ * This function creates a mutable scope from the current configuration data,
+ * applies the modifications specified in the [block], and returns a new [DispatchConfig] instance
+ * reflecting those changes.
+ *
+ * @param block A lambda with [DispatchConfigScope] as the receiver, used to define configuration modifications.
+ * @return A new `DispatchConfig` instance with the updates applied.
+ * @author Fantamomo
+ * @since 1.10-SNAPSHOT
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <E : Dispatchable> DispatchConfig<E>.modify(block: DispatchConfigScope<E>.() -> Unit): DispatchConfig<E> {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    if (this !is DispatchConfigImpl) return createDispatchConfig(block)
+    val scope = DispatchConfigScope<E>(this.dataAsMutable())
+    scope.block()
+    return DispatchConfig(scope)
+}
+
+/**
+ * Creates a new dispatch configuration using the provided configuration block.
+ *
+ * This function initializes a `DispatchConfigScope` for the generic type `E` and applies
+ * the user-defined block to configure the dispatch settings. It uses Kotlin contracts to
+ * ensure the block is called exactly once during execution.
+ *
+ * @param E The type of the dispatchable entity for which the dispatch configuration is defined.
+ * This must extend from `Dispatchable`.
+ * @param block A lambda with receiver of type `DispatchConfigScope<E>` that defines
+ * the configuration logic for the dispatch settings.
+ * @return A `DispatchConfig<E>` instance containing the configured dispatch settings.
+ * @author Fantamomo
+ * @since 1.10-SNAPSHOT
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <E : Dispatchable> createDispatchConfig(block: DispatchConfigScope<E>.() -> Unit): DispatchConfig<E> {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return DispatchConfig(DispatchConfigScope<E>().apply(block))
+}

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/keys.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/config/keys.kt
@@ -14,7 +14,7 @@ package com.fantamomo.kevent.manager.config
  * @author Fantamomo
  * @since 1.9-SNAPSHOT
  */
-var DispatchConfigScope.dispatchDeadEvent: Boolean
+var DispatchConfigScope<*>.dispatchDeadEvent: Boolean
     get() = getOrDefault(DispatchConfigKey.DISPATCH_DEAD_EVENT)
     set(value) = set(DispatchConfigKey.DISPATCH_DEAD_EVENT, value)
 
@@ -32,6 +32,6 @@ var DispatchConfigScope.dispatchDeadEvent: Boolean
  * @author Fantamomo
  * @since 1.9-SNAPSHOT
  */
-var DispatchConfigScope.sticky: Boolean
+var DispatchConfigScope<*>.sticky: Boolean
     get() = getOrDefault(DispatchConfigKey.STICKY)
     set(value) = set(DispatchConfigKey.STICKY, value)

--- a/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/dispatch.kt
+++ b/k-event-manager/src/commonMain/kotlin/com/fantamomo/kevent/manager/dispatch.kt
@@ -1,8 +1,11 @@
 package com.fantamomo.kevent.manager
 
 import com.fantamomo.kevent.Dispatchable
-import com.fantamomo.kevent.manager.config.DispatchConfig
 import com.fantamomo.kevent.manager.config.DispatchConfigScope
+import com.fantamomo.kevent.manager.config.createDispatchConfig
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * Dispatches an event to all registered listeners with a configurable dispatch scope.
@@ -16,10 +19,10 @@ import com.fantamomo.kevent.manager.config.DispatchConfigScope
  * @since 1.9-SNAPSHOT
  * @author Fantamomo
  */
-inline fun <E : Dispatchable> EventManager.dispatch(event: E, config: DispatchConfigScope.() -> Unit) {
-    val scope = DispatchConfigScope()
-    scope.config()
-    dispatch(event, DispatchConfig(scope))
+@OptIn(ExperimentalContracts::class)
+inline fun <E : Dispatchable> EventManager.dispatch(event: E, config: DispatchConfigScope<E>.() -> Unit) {
+    contract { callsInPlace(config, InvocationKind.EXACTLY_ONCE) }
+    dispatch(event, createDispatchConfig(config))
 }
 
 /**
@@ -35,8 +38,8 @@ inline fun <E : Dispatchable> EventManager.dispatch(event: E, config: DispatchCo
  * @since 1.9-SNAPSHOT
  * @author Fantamomo
  */
-suspend inline fun <E : Dispatchable> EventManager.dispatchSuspend(event: E, config: DispatchConfigScope.() -> Unit) {
-    val scope = DispatchConfigScope()
-    scope.config()
-    dispatchSuspend(event, DispatchConfig(scope))
+@OptIn(ExperimentalContracts::class)
+suspend inline fun <E : Dispatchable> EventManager.dispatchSuspend(event: E, config: DispatchConfigScope<E>.() -> Unit) {
+    contract { callsInPlace(config, InvocationKind.EXACTLY_ONCE) }
+    dispatchSuspend(event, createDispatchConfig(config))
 }


### PR DESCRIPTION
This pull request introduces multiple improvements to the dispatch and configuration APIs. 

- **Documentation Enhancements**: Added new documentation for sticky events. Included details on the `isSticky` parameter, usage examples, and behavior.
  
- **API Improvements**:
  - Introduced a type parameter `<D : Dispatchable>` to `dispatch` and `dispatchSuspend` functions.
  - Added contracts with `@OptIn(ExperimentalContracts::class)` and DSL-based scoping for `DispatchConfig`.
  - Enhanced `DispatchConfigScope` constructors for flexibility, adding mutability and type constraints.
  - Refactored `DispatchConfig` class into a sealed interface with implementations `Empty` and `DispatchConfigImpl`.
  
- **Refinements**:
  - Refined generic type parameters for `dispatchDeadEvent` and `sticky` properties for consistency and type safety.