### PR TITLE
Add support for ignoring sticky events in event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ configuration(event) {
     priority = Priority.HIGH
     disallowSubtypes = true
     exclusiveListenerProcessing = true
+    silent = true
+    ignoreStickyEvents = true
     name = "JoinHandler"
 }
 ```
@@ -137,8 +139,9 @@ configuration(event) {
 * `disallowSubtypes`: If `true`, only matches this exact event class.
 * `exclusiveListenerProcessing`: Prevents this handler from running concurrently. 
 This applies per `SharedExclusiveExecution` instance.
-* `name`: Optional debug label for this method.
 * `silent`: If `true`, the handler will not prevent `DeadEvent` from being emitted.
+* `ignoreStickyEvents`: If `true`, the handler will not receive sticky events.
+* `name`: Optional debug label for this method.
 
 The configuration is stored inside the manager’s registry and used every time this event is dispatched.
 

--- a/k-event-api/build.gradle.kts
+++ b/k-event-api/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.2-SNAPSHOT"
+version = "1.3-SNAPSHOT"
 
 kotlin {
 

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Key.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Key.kt
@@ -1,5 +1,6 @@
 package com.fantamomo.kevent
 
+import com.fantamomo.kevent.Key.Companion.PRIORITY
 import kotlin.reflect.KClass
 
 /**
@@ -95,6 +96,22 @@ data class Key<T>(val key: String, val type: KClass<T & Any>, val defaultValue: 
          * @see com.fantamomo.kevent.silent
          */
         val SILENT = Key<Boolean>("silent", false)
+
+        /**
+         * A key used to specify whether sticky events should be ignored in event handling.
+         *
+         * The `IGNORE_STICKY_EVENTS` key determines if handlers should bypass processing of
+         * previously posted "sticky" events. Sticky events are retained in memory after being
+         * dispatched, allowing new subscribers to immediately receive the latest sticky event.
+         * Enabling this key disables such behavior, ensuring only real-time events are processed.
+         *
+         * Default value: `false` (handlers will process sticky events by default).
+         *
+         * @see Key
+         * @see EventConfigurationScope.getOrDefault
+         * @since 1.3-SNAPSHOT
+         */
+        val IGNORE_STICKY_EVENTS = Key<Boolean>("ignoreStickyEvents", false)
 
         /**
          * Represents a debug-only key with a name identifier.

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/options.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/options.kt
@@ -93,6 +93,23 @@ var EventConfigurationScope<*>.silent: Boolean
     set(value) = set(Key.SILENT, value)
 
 /**
+ * Configures whether sticky events should be ignored for the current event handler configuration.
+ *
+ * Sticky events are events that have been dispatched before the handler was registered and are typically
+ * replayed to new handlers to ensure they are processed. When this property is set to `true`, the event
+ * handler will not process any previously dispatched sticky events, regardless of their presence.
+ *
+ * By default, this value is determined by the default configuration of the associated [Key].
+ *
+ * @property ignoreStickyEvents A `Boolean` value indicating whether to ignore sticky events.
+ * @author Fantamomo
+ * @since 1.3-SNAPSHOT
+ */
+var EventConfigurationScope<*>.ignoreStickyEvents: Boolean
+    get() = getOrDefault(Key.IGNORE_STICKY_EVENTS)
+    set(value) = set(Key.IGNORE_STICKY_EVENTS, value)
+
+/**
  * Use to set the name of a Listener.
  *
  * It may potentially be used by other systems in the future for further expansion

--- a/k-event-manager/build.gradle.kts
+++ b/k-event-manager/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.10-SNAPSHOT"
+version = "1.11-SNAPSHOT"
 
 kotlin {
 


### PR DESCRIPTION
### Summary

- Added a new `ignoreStickyEvents` property in the `EventConfigurationScope` to control the processing of sticky events.
- Enhanced sticky event handling in the event manager to skip processing if `IGNORE_STICKY_EVENTS` is configured.
- Introduced the `IGNORE_STICKY_EVENTS` key for event handling configuration.
- Improved KDoc descriptions for the `ignoreStickyEvents` property, detailing its purpose and behavior.
- Updated the README with an explanation of `ignoreStickyEvents` and adjusted configuration property descriptions for better clarity.
- Bumped project versions:
  - `k-event-manager` to `1.11-SNAPSHOT`
  - `k-event-api` to `1.3-SNAPSHOT`.