### PR TITLE
Update API version and correct exception message

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ You can use the `api` module even in shared/common codebases.
 
 ## Built by Fantamomo
 
-API-Version: **1.7-SNAPSHOT**
+API-Version: **1.7.1-SNAPSHOT**
 Manager-Version: **1.18-SNAPSHOT**
 
 Happy event handling!

--- a/k-event-api/build.gradle.kts
+++ b/k-event-api/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.fantamomo"
-version = "1.7-SNAPSHOT"
+version = "1.7.1-SNAPSHOT"
 
 kotlin {
 

--- a/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Priority.kt
+++ b/k-event-api/src/commonMain/kotlin/com/fantamomo/kevent/Priority.kt
@@ -112,7 +112,7 @@ sealed interface Priority : Comparable<Priority> {
                 "LOW" -> LOW
                 "LOWEST" -> LOWEST
                 "MONITOR" -> MONITOR
-                else -> throw IllegalArgumentException("No object ${Standard::class.qualifiedName}.$value")
+                else -> throw IllegalArgumentException("No object com.fantamomo.kevent.Priority.$value")
             }
         }
     }


### PR DESCRIPTION
- Fixed an issue where the exception message in `Priority` parsing throw a compiler error.
- Bumped the API version to `1.7.1-SNAPSHOT` in `README.md` and `build.gradle.kts`.